### PR TITLE
Stop using new variables for the globalflags.ProjectIdFlag and Docs generation

### DIFF
--- a/docs/stackit.md
+++ b/docs/stackit.md
@@ -33,6 +33,7 @@ stackit [flags]
 * [stackit config](./stackit_config.md)	 - Provides functionality for CLI configuration options
 * [stackit curl](./stackit_curl.md)	 - Executes an authenticated HTTP request to an endpoint
 * [stackit dns](./stackit_dns.md)	 - Provides functionality for DNS
+* [stackit git](./stackit_git.md)	 - Provides functionality for STACKIT Git
 * [stackit image](./stackit_image.md)	 - Manage server images
 * [stackit key-pair](./stackit_key-pair.md)	 - Provides functionality for SSH key pairs
 * [stackit load-balancer](./stackit_load-balancer.md)	 - Provides functionality for Load Balancer

--- a/docs/stackit_git.md
+++ b/docs/stackit_git.md
@@ -1,0 +1,37 @@
+## stackit git
+
+Provides functionality for STACKIT Git
+
+### Synopsis
+
+Provides functionality for STACKIT Git.
+
+```
+stackit git [flags]
+```
+
+### Options
+
+```
+  -h, --help   Help for "stackit git"
+```
+
+### Options inherited from parent commands
+
+```
+  -y, --assume-yes             If set, skips all confirmation prompts
+      --async                  If set, runs the command asynchronously
+  -o, --output-format string   Output format, one of ["json" "pretty" "none" "yaml"]
+  -p, --project-id string      Project ID
+      --region string          Target region for region-specific requests
+      --verbosity string       Verbosity of the CLI, one of ["debug" "info" "warning" "error"] (default "info")
+```
+
+### SEE ALSO
+
+* [stackit](./stackit.md)	 - Manage STACKIT resources using the command line
+* [stackit git create](./stackit_git_create.md)	 - Creates STACKIT Git instance
+* [stackit git delete](./stackit_git_delete.md)	 - Deletes STACKIT Git instance
+* [stackit git describe](./stackit_git_describe.md)	 - Describes STACKIT Git instance
+* [stackit git list](./stackit_git_list.md)	 - Lists all instances of STACKIT Git.
+

--- a/docs/stackit_git_create.md
+++ b/docs/stackit_git_create.md
@@ -1,0 +1,41 @@
+## stackit git create
+
+Creates STACKIT Git instance
+
+### Synopsis
+
+Create an STACKIT Git instance by name.
+
+```
+stackit git create [flags]
+```
+
+### Examples
+
+```
+  Create an instance with name 'my-new-instance'
+  $ stackit git create --name my-new-instance
+```
+
+### Options
+
+```
+  -h, --help          Help for "stackit git create"
+      --name string   The name of the instance.
+```
+
+### Options inherited from parent commands
+
+```
+  -y, --assume-yes             If set, skips all confirmation prompts
+      --async                  If set, runs the command asynchronously
+  -o, --output-format string   Output format, one of ["json" "pretty" "none" "yaml"]
+  -p, --project-id string      Project ID
+      --region string          Target region for region-specific requests
+      --verbosity string       Verbosity of the CLI, one of ["debug" "info" "warning" "error"] (default "info")
+```
+
+### SEE ALSO
+
+* [stackit git](./stackit_git.md)	 - Provides functionality for STACKIT Git
+

--- a/docs/stackit_git_delete.md
+++ b/docs/stackit_git_delete.md
@@ -1,0 +1,40 @@
+## stackit git delete
+
+Deletes STACKIT Git instance
+
+### Synopsis
+
+Deletes an STACKIT Git instance by its internal ID.
+
+```
+stackit git delete INSTANCE_ID [flags]
+```
+
+### Examples
+
+```
+  Delete an instance with ID "xxx"
+  $ stackit git delete xxx
+```
+
+### Options
+
+```
+  -h, --help   Help for "stackit git delete"
+```
+
+### Options inherited from parent commands
+
+```
+  -y, --assume-yes             If set, skips all confirmation prompts
+      --async                  If set, runs the command asynchronously
+  -o, --output-format string   Output format, one of ["json" "pretty" "none" "yaml"]
+  -p, --project-id string      Project ID
+      --region string          Target region for region-specific requests
+      --verbosity string       Verbosity of the CLI, one of ["debug" "info" "warning" "error"] (default "info")
+```
+
+### SEE ALSO
+
+* [stackit git](./stackit_git.md)	 - Provides functionality for STACKIT Git
+

--- a/docs/stackit_git_describe.md
+++ b/docs/stackit_git_describe.md
@@ -1,0 +1,40 @@
+## stackit git describe
+
+Describes STACKIT Git instance
+
+### Synopsis
+
+Describes an STACKIT Git instance by its internal ID.
+
+```
+stackit git describe INSTANCE_ID [flags]
+```
+
+### Examples
+
+```
+  Describe instance "xxx"
+  $ stackit git describe xxx
+```
+
+### Options
+
+```
+  -h, --help   Help for "stackit git describe"
+```
+
+### Options inherited from parent commands
+
+```
+  -y, --assume-yes             If set, skips all confirmation prompts
+      --async                  If set, runs the command asynchronously
+  -o, --output-format string   Output format, one of ["json" "pretty" "none" "yaml"]
+  -p, --project-id string      Project ID
+      --region string          Target region for region-specific requests
+      --verbosity string       Verbosity of the CLI, one of ["debug" "info" "warning" "error"] (default "info")
+```
+
+### SEE ALSO
+
+* [stackit git](./stackit_git.md)	 - Provides functionality for STACKIT Git
+

--- a/docs/stackit_git_list.md
+++ b/docs/stackit_git_list.md
@@ -1,0 +1,40 @@
+## stackit git list
+
+Lists all instances of STACKIT Git.
+
+### Synopsis
+
+Lists all instances of STACKIT Git for the current project.
+
+```
+stackit git list [flags]
+```
+
+### Examples
+
+```
+  List all STACKIT Git instances
+  $ stackit git instance list
+```
+
+### Options
+
+```
+  -h, --help   Help for "stackit git list"
+```
+
+### Options inherited from parent commands
+
+```
+  -y, --assume-yes             If set, skips all confirmation prompts
+      --async                  If set, runs the command asynchronously
+  -o, --output-format string   Output format, one of ["json" "pretty" "none" "yaml"]
+  -p, --project-id string      Project ID
+      --region string          Target region for region-specific requests
+      --verbosity string       Verbosity of the CLI, one of ["debug" "info" "warning" "error"] (default "info")
+```
+
+### SEE ALSO
+
+* [stackit git](./stackit_git.md)	 - Provides functionality for STACKIT Git
+

--- a/internal/cmd/git/create/create.go
+++ b/internal/cmd/git/create/create.go
@@ -33,8 +33,8 @@ type inputModel struct {
 func NewCmd(p *print.Printer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
-		Short: "Creates stackit git instance",
-		Long:  "Create an stackit git instance by name.",
+		Short: "Creates STACKIT Git instance",
+		Long:  "Create an STACKIT Git instance by name.",
 		Args:  args.NoArgs,
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/git/create/create_test.go
+++ b/internal/cmd/git/create/create_test.go
@@ -13,8 +13,6 @@ import (
 	"github.com/stackitcloud/stackit-sdk-go/services/git"
 )
 
-var projectIdFlag = globalflags.ProjectIdFlag
-
 type testCtxKey struct{}
 
 var (
@@ -27,7 +25,7 @@ var (
 
 func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]string {
 	flagValues := map[string]string{
-		projectIdFlag: testProjectId,
+		globalflags.ProjectIdFlag: testProjectId,
 
 		nameFlag: testName,
 	}
@@ -90,21 +88,21 @@ func TestParseInput(t *testing.T) {
 		{
 			description: "project id missing",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				delete(flagValues, projectIdFlag)
+				delete(flagValues, globalflags.ProjectIdFlag)
 			}),
 			isValid: false,
 		},
 		{
 			description: "project id invalid 1",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[projectIdFlag] = ""
+				flagValues[globalflags.ProjectIdFlag] = ""
 			}),
 			isValid: false,
 		},
 		{
 			description: "project id invalid 2",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[projectIdFlag] = "invalid-uuid"
+				flagValues[globalflags.ProjectIdFlag] = "invalid-uuid"
 			}),
 			isValid: false,
 		},

--- a/internal/cmd/git/delete/delete_test.go
+++ b/internal/cmd/git/delete/delete_test.go
@@ -13,8 +13,6 @@ import (
 	"github.com/stackitcloud/stackit-sdk-go/services/git"
 )
 
-var projectIdFlag = globalflags.ProjectIdFlag
-
 type testCtxKey struct{}
 
 var (
@@ -26,7 +24,7 @@ var (
 
 func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]string {
 	flagValues := map[string]string{
-		projectIdFlag: testProjectId,
+		globalflags.ProjectIdFlag: testProjectId,
 	}
 	for _, mod := range mods {
 		mod(flagValues)
@@ -71,14 +69,14 @@ func TestParseInput(t *testing.T) {
 		{
 			description: "project id invalid 1",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[projectIdFlag] = ""
+				flagValues[globalflags.ProjectIdFlag] = ""
 			}),
 			isValid: false,
 		},
 		{
 			description: "project id invalid 2",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[projectIdFlag] = "invalid-uuid"
+				flagValues[globalflags.ProjectIdFlag] = "invalid-uuid"
 			}),
 			isValid: false,
 		},

--- a/internal/cmd/git/describe/describe_test.go
+++ b/internal/cmd/git/describe/describe_test.go
@@ -12,8 +12,6 @@ import (
 	"github.com/stackitcloud/stackit-sdk-go/services/git"
 )
 
-var projectIdFlag = globalflags.ProjectIdFlag
-
 type testCtxKey struct{}
 
 var (
@@ -25,7 +23,7 @@ var (
 
 func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]string {
 	flagValues := map[string]string{
-		projectIdFlag: testProjectId,
+		globalflags.ProjectIdFlag: testProjectId,
 	}
 	for _, mod := range mods {
 		mod(flagValues)
@@ -76,7 +74,7 @@ func TestParseInput(t *testing.T) {
 		{
 			description: "project id missing",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				delete(flagValues, projectIdFlag)
+				delete(flagValues, globalflags.ProjectIdFlag)
 			}),
 			args:    testInstanceId,
 			isValid: false,
@@ -84,7 +82,7 @@ func TestParseInput(t *testing.T) {
 		{
 			description: "project id invalid 1",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[projectIdFlag] = ""
+				flagValues[globalflags.ProjectIdFlag] = ""
 			}),
 			args:    testInstanceId,
 			isValid: false,
@@ -92,7 +90,7 @@ func TestParseInput(t *testing.T) {
 		{
 			description: "project id invalid 2",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[projectIdFlag] = "invalid-uuid"
+				flagValues[globalflags.ProjectIdFlag] = "invalid-uuid"
 			}),
 			args:    testInstanceId,
 			isValid: false,

--- a/internal/cmd/git/list/list.go
+++ b/internal/cmd/git/list/list.go
@@ -27,7 +27,7 @@ func NewCmd(p *print.Printer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "Lists all instances of STACKIT Git.",
-		Long:  "Lists all instances of STACKIT Git current the current project.",
+		Long:  "Lists all instances of STACKIT Git for the current project.",
 		Args:  args.NoArgs,
 		Example: examples.Build(
 			examples.NewExample(

--- a/internal/cmd/git/list/list_test.go
+++ b/internal/cmd/git/list/list_test.go
@@ -12,8 +12,6 @@ import (
 	"github.com/stackitcloud/stackit-sdk-go/services/git"
 )
 
-var projectIdFlag = globalflags.ProjectIdFlag
-
 type testCtxKey struct{}
 
 var testCtx = context.WithValue(context.Background(), testCtxKey{}, "foo")
@@ -22,7 +20,7 @@ var testProjectId = uuid.NewString()
 
 func fixtureFlagValues(mods ...func(flagValues map[string]string)) map[string]string {
 	flagValues := map[string]string{
-		projectIdFlag: testProjectId,
+		globalflags.ProjectIdFlag: testProjectId,
 	}
 	for _, mod := range mods {
 		mod(flagValues)
@@ -72,21 +70,21 @@ func TestParseInput(t *testing.T) {
 		{
 			description: "project id missing",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				delete(flagValues, projectIdFlag)
+				delete(flagValues, globalflags.ProjectIdFlag)
 			}),
 			isValid: false,
 		},
 		{
 			description: "project id invalid 1",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[projectIdFlag] = ""
+				flagValues[globalflags.ProjectIdFlag] = ""
 			}),
 			isValid: false,
 		},
 		{
 			description: "project id invalid 2",
 			flagValues: fixtureFlagValues(func(flagValues map[string]string) {
-				flagValues[projectIdFlag] = "invalid-uuid"
+				flagValues[globalflags.ProjectIdFlag] = "invalid-uuid"
 			}),
 			isValid: false,
 		},


### PR DESCRIPTION
## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

relates to #1234

## Checklist

- [ ] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-cli/blob/ef291d1683ca5b0d719ec0a26ecb999a32685117/internal/cmd/ske/cluster/create/create.go#L49-L63))
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 
